### PR TITLE
Convert `createWriteStream` to `createWriteStreamSync`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,17 @@ const insights = require('./applicationinsights')
 const streams = require('./streams')
 const pumpify = require('pumpify')
 
-async function createWriteStream (options = {}) {
+function createWriteStreamSync (
+  /**
+   * @type {{
+   *   setup?: (
+   *     appInsights: typeof import('applicationinsights')
+   *   ) => typeof import('applicationinsights').Configuration,
+   *   key?: string
+   * }}
+   */
+  options = {}
+) {
   if (!options.setup && !options.key && !process.env.APPINSIGHTS_INSTRUMENTATIONKEY) { throw Error('Instrumentation key missing') }
   const client = new insights.Client(options)
 
@@ -16,4 +26,4 @@ async function createWriteStream (options = {}) {
   return pumpify(parseJsonStream, batchStream, writeStream)
 }
 
-module.exports.createWriteStream = createWriteStream
+module.exports.createWriteStreamSync = createWriteStreamSync


### PR DESCRIPTION
Users will get an import error when updating.
I think it should be pretty easy to fix.

#### Checklist

- [ ] run `npm run test`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows *Code Of Conduct*
